### PR TITLE
Add default arguments to TagRelatedModule::toString()

### DIFF
--- a/Hashtag/modules/class.tagrelatedmodule.php
+++ b/Hashtag/modules/class.tagrelatedmodule.php
@@ -5,7 +5,7 @@ class TagRelatedModule extends Gdn_Module {
  protected $ConversationString;
 
 /////////////////////////////////////
-  public function toString ($Sender,$Args) {
+  public function toString ($Sender = null, $Args = null) {
 	global $ConversationString ;
 	//$Msg = __FUNCTION__.' '.__LINE__.' Called by: ' . debug_backtrace()[1]['function'].debug_backtrace()[0]['line'].' ---> '. 	debug_backtrace()[0]['function'];
 	//return $Msg;


### PR DESCRIPTION
For vanilla/alltags (Vanilla 2.6) I get:

    Too few arguments to function TagRelatedModule::toString(), 0 passed in /www/htdocs/library/core/class.module.php on line 258 and exactly 2 expected